### PR TITLE
商品削除機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,6 @@
 class ItemsController < ApplicationController
-  before_action :authenticate_user!, only: [:new, :create, :edit]
-  before_action :set_item, only: [:show, :edit, :update]
+  before_action :authenticate_user!, only: [:new, :create, :edit, :destroy]
+  before_action :set_item, only: [:show, :edit, :update, :destroy]
   def index
     @items = Item.order(created_at: :desc)
   end
@@ -31,6 +31,11 @@ class ItemsController < ApplicationController
     else
       render :edit, status: :unprocessable_entity
     end
+  end
+
+  def destroy
+    @item.destroy if @item.user == current_user
+    redirect_to root_path
   end
 
   private

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -28,7 +28,7 @@
    <% if user_signed_in? && @item.user == current_user %>
     <%= link_to "商品の編集", edit_item_path(@item), class: "item-red-btn" %>
     <p class="or-text">or</p>
-    <%= link_to '削除', item_path(@item), method: :delete, data: { confirm: '本当に削除しますか？' }, class: 'item-destroy btn btn-danger' %>   <% elsif user_signed_in? %>
+    <%= link_to '削除', item_path(@item), method: :delete, class: 'item-destroy btn btn-danger' %>   <% elsif user_signed_in? %>
     <%= link_to "購入画面に進む", "#", class: "item-red-btn" %>
    <% end %>
 

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -28,8 +28,7 @@
    <% if user_signed_in? && @item.user == current_user %>
     <%= link_to "商品の編集", edit_item_path(@item), class: "item-red-btn" %>
     <p class="or-text">or</p>
-    <%= link_to "削除", "#", class: "item-destroy" %>
-   <% elsif user_signed_in? %>
+    <%= link_to '削除', item_path(@item), method: :delete, data: { confirm: '本当に削除しますか？' }, class: 'item-destroy btn btn-danger' %>   <% elsif user_signed_in? %>
     <%= link_to "購入画面に進む", "#", class: "item-red-btn" %>
    <% end %>
 

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -28,7 +28,7 @@
    <% if user_signed_in? && @item.user == current_user %>
     <%= link_to "商品の編集", edit_item_path(@item), class: "item-red-btn" %>
     <p class="or-text">or</p>
-    <%= link_to '削除', item_path(@item), method: :delete, class: 'item-destroy btn btn-danger' %>   <% elsif user_signed_in? %>
+    <%= link_to '削除', item_path(@item), data: { turbo_method: :delete }, class: 'item-destroy btn btn-danger' %>   <% elsif user_signed_in? %>
     <%= link_to "購入画面に進む", "#", class: "item-red-btn" %>
    <% end %>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
   devise_for :users
   root to: 'items#index'
-  resources :items, only: [:index, :show, :new, :create, :edit, :update]
+resources :items, only: [:index, :show, :new, :create, :edit, :update, :destroy]
 end


### PR DESCRIPTION
# What
商品削除機能を実装のため

destroyアクションのルーティングを設定
商品詳細ページに削除ボタンを設置
ItemsControllerにdestroyアクションを定義
出品者のみが商品を削除できるよう制限
削除成功時はトップページへリダイレクト

# Why

出品者が不要になった商品を削除できるようにするため

# 提出動画
ログイン状態の出品者のみ、詳細ページの削除ボタンを押すと、出品した商品を削除できる動画
https://gyazo.com/4a5ec41516c854b10fd4bd218e859fc8

ご確認くださいませ